### PR TITLE
Add auth and profile features

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,1 @@
+from . import models, schemas, auth

--- a/app/auth.py
+++ b/app/auth.py
@@ -1,0 +1,74 @@
+from datetime import datetime, timedelta
+from typing import Optional
+
+from fastapi import Depends, HTTPException, status
+from fastapi.security import OAuth2PasswordBearer, OAuth2PasswordRequestForm
+from jose import JWTError, jwt
+from passlib.context import CryptContext
+from sqlalchemy.orm import Session
+
+from . import models, schemas
+from .database import get_db
+
+SECRET_KEY = "secret"
+ALGORITHM = "HS256"
+ACCESS_TOKEN_EXPIRE_MINUTES = 30
+
+pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl="token")
+
+
+def verify_password(plain_password, hashed_password):
+    return pwd_context.verify(plain_password, hashed_password)
+
+
+def get_password_hash(password):
+    return pwd_context.hash(password)
+
+
+def get_user_by_username(db: Session, username: str) -> Optional[models.user.User]:
+    return (
+        db.query(models.user.User).filter(models.user.User.username == username).first()
+    )
+
+
+def authenticate_user(db: Session, username: str, password: str):
+    user = get_user_by_username(db, username)
+    if not user:
+        return False
+    if not verify_password(password, user.hashed_password):
+        return False
+    return user
+
+
+def create_access_token(data: dict, expires_delta: Optional[timedelta] = None):
+    to_encode = data.copy()
+    if expires_delta:
+        expire = datetime.utcnow() + expires_delta
+    else:
+        expire = datetime.utcnow() + timedelta(minutes=15)
+    to_encode.update({"exp": expire})
+    encoded_jwt = jwt.encode(to_encode, SECRET_KEY, algorithm=ALGORITHM)
+    return encoded_jwt
+
+
+async def get_current_user(
+    token: str = Depends(oauth2_scheme), db: Session = Depends(get_db)
+):
+    credentials_exception = HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="Could not validate credentials",
+        headers={"WWW-Authenticate": "Bearer"},
+    )
+    try:
+        payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
+        username: str = payload.get("sub")
+        if username is None:
+            raise credentials_exception
+        token_data = schemas.user.TokenData(username=username)
+    except JWTError:
+        raise credentials_exception
+    user = get_user_by_username(db, username=token_data.username)
+    if user is None:
+        raise credentials_exception
+    return user

--- a/app/database.py
+++ b/app/database.py
@@ -1,0 +1,19 @@
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker, declarative_base
+
+SQLALCHEMY_DATABASE_URL = "sqlite:///./test.db"
+
+engine = create_engine(
+    SQLALCHEMY_DATABASE_URL, connect_args={"check_same_thread": False}
+)
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+Base = declarative_base()
+
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()

--- a/app/main.py
+++ b/app/main.py
@@ -1,8 +1,68 @@
-from fastapi import FastAPI
+from fastapi import Depends, FastAPI, HTTPException, status
+from fastapi.security import OAuth2PasswordRequestForm
+from sqlalchemy.orm import Session
+
+from . import auth, models, schemas
+from .database import Base, engine, get_db
+
+
+Base.metadata.create_all(bind=engine)
 
 app = FastAPI()
 
-@app.get("/")
-async def read_root():
-    return {"message": "Hello, world"}
 
+@app.post("/users/", response_model=schemas.user.User)
+def create_user(user_in: schemas.user.UserCreate, db: Session = Depends(get_db)):
+    existing = auth.get_user_by_username(db, user_in.username)
+    if existing:
+        raise HTTPException(status_code=400, detail="Username already registered")
+    hashed_password = auth.get_password_hash(user_in.password)
+    user = models.user.User(username=user_in.username, hashed_password=hashed_password)
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return user
+
+
+@app.post("/token", response_model=schemas.user.Token)
+def login_for_access_token(
+    form_data: OAuth2PasswordRequestForm = Depends(), db: Session = Depends(get_db)
+):
+    user = auth.authenticate_user(db, form_data.username, form_data.password)
+    if not user:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Incorrect username or password",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+    access_token = auth.create_access_token(data={"sub": user.username})
+    return {"access_token": access_token, "token_type": "bearer"}
+
+
+@app.get("/users/me", response_model=schemas.user.User)
+async def read_users_me(
+    current_user: models.user.User = Depends(auth.get_current_user),
+):
+    return current_user
+
+
+@app.post("/profile", response_model=schemas.user.Profile)
+async def create_or_update_profile(
+    profile_in: schemas.user.ProfileCreate,
+    db: Session = Depends(get_db),
+    current_user: models.user.User = Depends(auth.get_current_user),
+):
+    profile = (
+        db.query(models.profile.Profile)
+        .filter(models.profile.Profile.user_id == current_user.id)
+        .first()
+    )
+    if not profile:
+        profile = models.profile.Profile(user_id=current_user.id, **profile_in.dict())
+        db.add(profile)
+    else:
+        for key, value in profile_in.dict().items():
+            setattr(profile, key, value)
+    db.commit()
+    db.refresh(profile)
+    return profile

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -1,0 +1,2 @@
+from .user import User
+from .profile import Profile

--- a/app/models/profile.py
+++ b/app/models/profile.py
@@ -1,0 +1,16 @@
+from sqlalchemy import Column, Integer, String, ForeignKey
+from sqlalchemy.orm import relationship
+
+from ..database import Base
+
+
+class Profile(Base):
+    __tablename__ = "profiles"
+
+    id = Column(Integer, primary_key=True, index=True)
+    user_id = Column(Integer, ForeignKey("users.id"))
+    full_name = Column(String, index=True)
+    photo = Column(String, nullable=True)
+    video = Column(String, nullable=True)
+
+    user = relationship("User", back_populates="profile")

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -1,0 +1,15 @@
+from sqlalchemy import Column, Integer, String
+from sqlalchemy.orm import relationship
+from .profile import Profile
+
+from ..database import Base
+
+
+class User(Base):
+    __tablename__ = "users"
+
+    id = Column(Integer, primary_key=True, index=True)
+    username = Column(String, unique=True, index=True)
+    hashed_password = Column(String)
+
+    profile = relationship("Profile", back_populates="user", uselist=False)

--- a/app/schemas/__init__.py
+++ b/app/schemas/__init__.py
@@ -1,0 +1,1 @@
+from . import user

--- a/app/schemas/user.py
+++ b/app/schemas/user.py
@@ -1,0 +1,43 @@
+from pydantic import BaseModel
+from typing import Optional
+
+
+class UserCreate(BaseModel):
+    username: str
+    password: str
+
+
+class Token(BaseModel):
+    access_token: str
+    token_type: str = "bearer"
+
+
+class TokenData(BaseModel):
+    username: Optional[str] = None
+
+
+class ProfileBase(BaseModel):
+    full_name: Optional[str] = None
+    photo: Optional[str] = None
+    video: Optional[str] = None
+
+
+class ProfileCreate(ProfileBase):
+    pass
+
+
+class Profile(ProfileBase):
+    id: int
+    user_id: int
+
+    class Config:
+        orm_mode = True
+
+
+class User(BaseModel):
+    id: int
+    username: str
+    profile: Optional[Profile] = None
+
+    class Config:
+        orm_mode = True

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,7 @@
 fastapi
 uvicorn
 psycopg2-binary
+SQLAlchemy
+python-jose[cryptography]
+passlib[bcrypt]
+python-multipart


### PR DESCRIPTION
## Summary
- add dependencies for auth and ORM
- implement SQLAlchemy database setup
- create models and schemas for users and profiles
- implement JWT authentication and profile endpoints

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f6afd499c832bb8f03bad12246c31